### PR TITLE
feat: implement when function to handle command states (success, failure, running, orElse)

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ calculateSquareCommand.execute(4);
 ```
 
 
-#### Minimal Usage: Handling Only Success State
+#### Minimal Usage: Handling Only Success State and orElse
 ```dart
 
 final calculateSquareCommand = Command1<int, int>(

--- a/README.md
+++ b/README.md
@@ -282,6 +282,99 @@ Future.delayed(Duration(seconds: 3), () {
 
 --- 
 
+### Example 5: using the map function
+
+Cancel long-running commands gracefully:
+```dart
+
+final calculateSquareCommand = Command1<int, int>(
+      (number) async {
+    if (number < 0) {
+      return Failure(Exception('Negative numbers are not allowed.'));
+    }
+    return Success(number * number);
+  },
+);
+
+calculateSquareCommand.addListener(() {
+    String? message = calculateSquareCommand.map<String>(
+        data: (value) => 'Square: $value',
+        error: (exception) => 'Error: ${exception?.message}',
+        running: () => 'Calculating...',
+    );
+
+    // Display the message in a snackbar
+    ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(message ?? '')),
+    );
+});
+// Execute the command with input
+calculateSquareCommand.execute(4);
+```
+
+#### Handling Unknown States with orElse
+
+```dart
+
+final calculateSquareCommand = Command1<int, int>(
+      (number) async {
+    if (number < 0) {
+      return Failure(Exception('Negative numbers are not allowed.'));
+    }
+    return Success(number * number);
+  },
+);
+
+calculateSquareCommand.addListener(() {
+    String? message = calculateSquareCommand.map<String>(
+        data: (value) => 'Square: $value',
+        error: (exception) => 'Error: ${exception?.message}',
+        orElse: () => 'Unknown state',
+    );
+
+    // Display the message in a snackbar
+    ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(message ?? '')),
+    );
+});
+// Execute the command with input
+calculateSquareCommand.execute(4);
+```
+
+
+#### Minimal Usage: Handling Only Success State
+```dart
+
+final calculateSquareCommand = Command1<int, int>(
+      (number) async {
+    if (number < 0) {
+      return Failure(Exception('Negative numbers are not allowed.'));
+    }
+    return Success(number * number);
+  },
+);
+
+calculateSquareCommand.addListener(() {
+    final message = calculateSquareCommand.map<String>(
+        data: (value) => 'Square: $value',
+    );
+
+    // Display the message in a snackbar
+    ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(message ?? '')),
+    );
+});
+// Execute the command with input
+calculateSquareCommand.execute(4);
+```
+
+**Notes**
+ - The function ensures type safety by requiring `data to handle the `success` state explicitly.
+ - The `orElse` callback is useful for dealing with unexpected states or adding default behavior.
+ - The `null` return value is possible only when no callback is matched and `orElse` is not provided.
+
+----
+
 ## Benefits for Your Team
 
 - **Simplified Collaboration**: Encapsulation makes it easier for teams to work independently on UI and business logic.

--- a/README.md
+++ b/README.md
@@ -297,15 +297,16 @@ final calculateSquareCommand = Command1<int, int>(
 );
 
 calculateSquareCommand.addListener(() {
-    String? message = calculateSquareCommand.map<String>(
+    final message = calculateSquareCommand.map<String>(
         data: (value) => 'Square: $value',
-        error: (exception) => 'Error: ${exception?.message}',
+        failure: (exception) => 'Error: ${exception?.message}',
         running: () => 'Calculating...',
+        orElse: () => 'default value',
     );
 
     // Display the message in a snackbar
     ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(message ?? '')),
+        SnackBar(content: Text(message)),
     );
 });
 // Execute the command with input
@@ -326,15 +327,15 @@ final calculateSquareCommand = Command1<int, int>(
 );
 
 calculateSquareCommand.addListener(() {
-    String? message = calculateSquareCommand.map<String>(
+    final message = calculateSquareCommand.map<String>(
         data: (value) => 'Square: $value',
-        error: (exception) => 'Error: ${exception?.message}',
-        orElse: () => 'Unknown state',
+        failure: (exception) => 'Error: ${exception?.message}',
+        orElse: () => 'default value',
     );
 
     // Display the message in a snackbar
     ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(message ?? '')),
+        SnackBar(content: Text(message)),
     );
 });
 // Execute the command with input
@@ -357,11 +358,12 @@ final calculateSquareCommand = Command1<int, int>(
 calculateSquareCommand.addListener(() {
     final message = calculateSquareCommand.map<String>(
         data: (value) => 'Square: $value',
+        orElse: () => 'default value',
     );
 
     // Display the message in a snackbar
     ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(message ?? '')),
+        SnackBar(content: Text(message)),
     );
 });
 // Execute the command with input

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ final calculateSquareCommand = Command1<int, int>(
 );
 
 calculateSquareCommand.addListener(() {
-    final message = calculateSquareCommand.map<String>(
+    final message = calculateSquareCommand.value.map<String>(
         data: (value) => 'Square: $value',
         failure: (exception) => 'Error: ${exception?.message}',
         running: () => 'Calculating...',
@@ -313,33 +313,28 @@ calculateSquareCommand.addListener(() {
 calculateSquareCommand.execute(4);
 ```
 
-#### Handling Unknown States with orElse
-
 ```dart
 
-final calculateSquareCommand = Command1<int, int>(
-      (number) async {
-    if (number < 0) {
-      return Failure(Exception('Negative numbers are not allowed.'));
-    }
-    return Success(number * number);
-  },
-);
-
-calculateSquareCommand.addListener(() {
-    final message = calculateSquareCommand.map<String>(
-        data: (value) => 'Square: $value',
-        failure: (exception) => 'Error: ${exception?.message}',
-        orElse: () => 'default value',
-    );
-
-    // Display the message in a snackbar
-    ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(message)),
-    );
-});
-// Execute the command with input
-calculateSquareCommand.execute(4);
+Widget build(BuildContext context) {
+  return Column(
+    children: [
+      ValueListenableBuilder<CommandState<bool>>(
+        valueListenable: loginCommand,
+        builder: (context, state, child) {
+          return state.map(
+            data: (_) => const Text('Login Successful!'),
+            running: () => const CircularProgressIndicator(),
+            failure: (error) => Text('Login Failed: $error'),
+            orElse: () => ElevatedButton(
+              onPressed: () => loginCommand.execute('admin', 'password'),
+              child: Text('Login'),
+            ),
+          );
+        },
+      ),
+    ],
+  );
+}
 ```
 
 
@@ -356,7 +351,7 @@ final calculateSquareCommand = Command1<int, int>(
 );
 
 calculateSquareCommand.addListener(() {
-    final message = calculateSquareCommand.map<String>(
+    final message = calculateSquareCommand.value.map<String>(
         data: (value) => 'Square: $value',
         orElse: () => 'default value',
     );

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ final calculateSquareCommand = Command1<int, int>(
 );
 
 calculateSquareCommand.addListener(() {
-    final message = calculateSquareCommand.value.map<String>(
+    final message = calculateSquareCommand.value.when<String>(
         data: (value) => 'Square: $value',
         failure: (exception) => 'Error: ${exception?.message}',
         running: () => 'Calculating...',
@@ -321,7 +321,7 @@ Widget build(BuildContext context) {
       ValueListenableBuilder<CommandState<bool>>(
         valueListenable: loginCommand,
         builder: (context, state, child) {
-          return state.map(
+          return state.when(
             data: (_) => const Text('Login Successful!'),
             running: () => const CircularProgressIndicator(),
             failure: (error) => Text('Login Failed: $error'),
@@ -351,7 +351,7 @@ final calculateSquareCommand = Command1<int, int>(
 );
 
 calculateSquareCommand.addListener(() {
-    final message = calculateSquareCommand.value.map<String>(
+    final message = calculateSquareCommand.value.when<String>(
         data: (value) => 'Square: $value',
         orElse: () => 'default value',
     );

--- a/lib/src/command.dart
+++ b/lib/src/command.dart
@@ -124,51 +124,6 @@ abstract class Command<T extends Object> extends ChangeNotifier
     addHistoryEntry(CommandHistoryEntry(state: newValue, metadata: metadata));
     notifyListeners(); // Notify listeners using ChangeNotifier.
   }
-
-  /// Maps the current state to a value of type [R] based on the object's state.
-  ///
-  /// This method allows you to handle different states of an object (`Idle`, `Cancelled`, `Running`, `Failure`, and `Success`),
-  /// and map each state to a corresponding value of type [R]. If no handler for a specific state is provided, the fallback
-  /// function [orElse] will be invoked.
-  ///
-  /// - [data]: Called when the state represents success, receiving a value of type [T] (the successful result).
-  /// - [failure]: Called when the state represents failure, receiving an [Exception?]. Optional.
-  /// - [cancelled]: Called when the state represents cancellation. Optional.
-  /// - [running]: Called when the state represents a running operation. Optional.
-  /// - [orElse]: A fallback function that is called when the state does not match any of the provided states.
-  ///   It is required and will be used when any of the other parameters are not provided or when no state matches.
-  ///
-  /// Returns a value of type [R] based on the state of the object. If no matching state handler is provided, the fallback
-  /// function [orElse] will be called.
-  ///
-  /// Example:
-  /// ```dart
-  /// final result = command.map<String>(
-  ///   data: (value) => 'Success: $value',
-  ///   failure: (e) => 'Error: ${e?.message}',
-  ///   cancelled: () => 'Cancelled',
-  ///   running: () => 'Running',
-  ///   orElse: () => 'Unknown state', // Required fallback function
-  /// );
-  /// ```
-  ///
-  /// If any of the optional parameters (`failure`, `cancelled`, `running`) are missing, you must provide [orElse]
-  /// to ensure a valid fallback is available.
-  R map<R>({
-    required R Function(T value) data,
-    R Function(Exception? exception)? failure,
-    R Function()? cancelled,
-    R Function()? running,
-    required Function() orElse,
-  }) {
-    return switch (value) {
-      IdleCommand<T>() => orElse.call(),
-      CancelledCommand<T>() => cancelled?.call() ?? orElse(),
-      RunningCommand<T>() => running?.call() ?? orElse(),
-      FailureCommand<T>(:final error) => failure?.call(error) ?? orElse(),
-      SuccessCommand<T>(:final value) => data.call(value) ?? orElse(),
-    };
-  }
 }
 
 /// A command that executes an action without any arguments.

--- a/lib/src/states.dart
+++ b/lib/src/states.dart
@@ -22,7 +22,7 @@ sealed class CommandState<T extends Object> {
   ///
   /// Example:
   /// ```dart
-  /// final result = command.map<String>(
+  /// final result = command.value.map<String>(
   ///   data: (value) => 'Success: $value',
   ///   failure: (e) => 'Error: ${e?.message}',
   ///   cancelled: () => 'Cancelled',

--- a/lib/src/states.dart
+++ b/lib/src/states.dart
@@ -3,6 +3,51 @@ part of 'command.dart';
 /// Base class representing the state of a command.
 sealed class CommandState<T extends Object> {
   const CommandState();
+
+  /// Maps the current state to a value of type [R] based on the object's state.
+  ///
+  /// This method allows you to handle different states of an object (`Idle`, `Cancelled`, `Running`, `Failure`, and `Success`),
+  /// and map each state to a corresponding value of type [R]. If no handler for a specific state is provided, the fallback
+  /// function [orElse] will be invoked.
+  ///
+  /// - [data]: Called when the state represents success, receiving a value of type [T] (the successful result).
+  /// - [failure]: Called when the state represents failure, receiving an [Exception?]. Optional.
+  /// - [cancelled]: Called when the state represents cancellation. Optional.
+  /// - [running]: Called when the state represents a running operation. Optional.
+  /// - [orElse]: A fallback function that is called when the state does not match any of the provided states.
+  ///   It is required and will be used when any of the other parameters are not provided or when no state matches.
+  ///
+  /// Returns a value of type [R] based on the state of the object. If no matching state handler is provided, the fallback
+  /// function [orElse] will be called.
+  ///
+  /// Example:
+  /// ```dart
+  /// final result = command.map<String>(
+  ///   data: (value) => 'Success: $value',
+  ///   failure: (e) => 'Error: ${e?.message}',
+  ///   cancelled: () => 'Cancelled',
+  ///   running: () => 'Running',
+  ///   orElse: () => 'Unknown state', // Required fallback function
+  /// );
+  /// ```
+  ///
+  /// If any of the optional parameters (`failure`, `cancelled`, `running`) are missing, you must provide [orElse]
+  /// to ensure a valid fallback is available.
+  R map<R>({
+    required R Function(T value) data,
+    R Function(Exception? exception)? failure,
+    R Function()? cancelled,
+    R Function()? running,
+    required Function() orElse,
+  }) {
+    return switch (this) {
+      IdleCommand<T>() => orElse.call(),
+      CancelledCommand<T>() => cancelled?.call() ?? orElse(),
+      RunningCommand<T>() => running?.call() ?? orElse(),
+      FailureCommand<T>(:final error) => failure?.call(error) ?? orElse(),
+      SuccessCommand<T>(:final value) => data.call(value) ?? orElse(),
+    };
+  }
 }
 
 /// Represents the idle state of a command (not running).

--- a/lib/src/states.dart
+++ b/lib/src/states.dart
@@ -22,7 +22,7 @@ sealed class CommandState<T extends Object> {
   ///
   /// Example:
   /// ```dart
-  /// final result = command.value.map<String>(
+  /// final result = command.value.when<String>(
   ///   data: (value) => 'Success: $value',
   ///   failure: (e) => 'Error: ${e?.message}',
   ///   cancelled: () => 'Cancelled',
@@ -33,7 +33,7 @@ sealed class CommandState<T extends Object> {
   ///
   /// If any of the optional parameters (`failure`, `cancelled`, `running`) are missing, you must provide [orElse]
   /// to ensure a valid fallback is available.
-  R map<R>({
+  R when<R>({
     required R Function(T value) data,
     R Function(Exception? exception)? failure,
     R Function()? cancelled,

--- a/test/src/command_test.dart
+++ b/test/src/command_test.dart
@@ -420,7 +420,8 @@ void main() {
       final result = command.map(
         data: (_) => 'none',
         running: () => 'running',
-        error: (exception) => exception.toString(),
+        failure: (exception) => exception.toString(),
+        orElse: () => 'default value',
       );
 
       expect(result, 'Exception: failure');
@@ -435,7 +436,8 @@ void main() {
       final result = command.map(
         data: (value) => value,
         running: () => 'running',
-        error: (exception) => exception.toString(),
+        failure: (exception) => exception.toString(),
+        orElse: () => 'default value',
       );
 
       expect(result, 'some');
@@ -453,7 +455,8 @@ void main() {
       final result = command.map(
         data: (value) => value,
         running: () => 'running',
-        error: (exception) => exception.toString(),
+        failure: (exception) => exception.toString(),
+        orElse: () => 'default value',
       );
 
       expect(result, 'some');
@@ -466,12 +469,12 @@ void main() {
 
       await command.execute();
 
-      final result = command.map(
-        data: (value) => value == 'otherValue',
-        orElse: () => 'defaultValue',
+      final result = command.map<String>(
+        data: (value) => 'otherValue',
+        orElse: () => 'default value',
       );
 
-      expect(result, 'defaultValue');
+      expect(result, 'default value');
     });
   });
 }

--- a/test/src/command_test.dart
+++ b/test/src/command_test.dart
@@ -408,5 +408,70 @@ void main() {
       expect(command.isSuccess, isFalse);
       expect(command.isFailure, isTrue);
     });
+
+    test(
+        'map() handles failure state correctly, returning the exception message',
+        () async {
+      final command =
+          Command0<String>(() async => Failure(Exception('failure')));
+
+      await command.execute();
+
+      final result = command.map(
+        data: (_) => 'none',
+        running: () => 'running',
+        error: (exception) => exception.toString(),
+      );
+
+      expect(result, 'Exception: failure');
+    });
+
+    test('map() correctly handles success state, returning the success value',
+        () async {
+      final command = Command0<String>(() async => const Success('some'));
+
+      await command.execute();
+
+      final result = command.map(
+        data: (value) => value,
+        running: () => 'running',
+        error: (exception) => exception.toString(),
+      );
+
+      expect(result, 'some');
+    });
+
+    test(
+        'map() correctly handles success state with input parameter, returning the success value',
+        () async {
+      final command = Command1<String, String>(
+        (String text) async => const Success('some'),
+      );
+
+      await command.execute('param');
+
+      final result = command.map(
+        data: (value) => value,
+        running: () => 'running',
+        error: (exception) => exception.toString(),
+      );
+
+      expect(result, 'some');
+    });
+
+    test(
+        'map() returns the default value when no state matches and orElse is provided',
+        () async {
+      final command = Command0<String>(() async => Failure(Exception('none')));
+
+      await command.execute();
+
+      final result = command.map(
+        data: (value) => value == 'otherValue',
+        orElse: () => 'defaultValue',
+      );
+
+      expect(result, 'defaultValue');
+    });
   });
 }

--- a/test/src/command_test.dart
+++ b/test/src/command_test.dart
@@ -417,7 +417,7 @@ void main() {
 
       await command.execute();
 
-      final result = command.value.map(
+      final result = command.value.when(
         data: (_) => 'none',
         running: () => 'running',
         failure: (exception) => exception.toString(),
@@ -433,7 +433,7 @@ void main() {
 
       await command.execute();
 
-      final result = command.value.map(
+      final result = command.value.when(
         data: (value) => value,
         running: () => 'running',
         failure: (exception) => exception.toString(),
@@ -452,7 +452,7 @@ void main() {
 
       await command.execute('param');
 
-      final result = command.value.map(
+      final result = command.value.when(
         data: (value) => value,
         running: () => 'running',
         failure: (exception) => exception.toString(),
@@ -469,7 +469,7 @@ void main() {
 
       await command.execute();
 
-      final result = command.value.map<String>(
+      final result = command.value.when<String>(
         data: (value) => 'otherValue',
         orElse: () => 'default value',
       );

--- a/test/src/command_test.dart
+++ b/test/src/command_test.dart
@@ -417,7 +417,7 @@ void main() {
 
       await command.execute();
 
-      final result = command.map(
+      final result = command.value.map(
         data: (_) => 'none',
         running: () => 'running',
         failure: (exception) => exception.toString(),
@@ -433,7 +433,7 @@ void main() {
 
       await command.execute();
 
-      final result = command.map(
+      final result = command.value.map(
         data: (value) => value,
         running: () => 'running',
         failure: (exception) => exception.toString(),
@@ -452,7 +452,7 @@ void main() {
 
       await command.execute('param');
 
-      final result = command.map(
+      final result = command.value.map(
         data: (value) => value,
         running: () => 'running',
         failure: (exception) => exception.toString(),
@@ -469,7 +469,7 @@ void main() {
 
       await command.execute();
 
-      final result = command.map<String>(
+      final result = command.value.map<String>(
         data: (value) => 'otherValue',
         orElse: () => 'default value',
       );


### PR DESCRIPTION
### Maps the current state to a value of type `.when<R>` based on the object's state.
Returns the result of the callback corresponding to the current state or the result of [orElse] if provided and no state matches.
##### Example:
 
```dart
final result = command.value.when<String>(
  data: (value) => 'Success: $value',
  error: (e) => 'Error: ${e?.message}',
  running: () => 'Running',
  orElse: () => 'Unknown state',
);
```

Minimal Usage: Handling Only Success State  and orElse

```dart
final result = command.value.when<String>(
  data: (value) => 'Success: $value',
  orElse: () => 'Unknown state',
);
```
